### PR TITLE
Add Jenkinsfile for EMF Forms build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/syna"]
 	path = themes/syna
-	url = git@github.com:eclipsesource/syna.git
+	url = https://github.com/eclipsesource/syna.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,119 @@
+pipeline {
+  agent {
+    kubernetes {
+      label 'hugo-agent'
+      yaml """
+apiVersion: v1
+metadata:
+  labels:
+    run: hugo
+  name: hugo-pod
+spec:
+  containers:
+    - name: jnlp
+      volumeMounts:
+      - mountPath: /home/jenkins/.ssh
+        name: volume-known-hosts
+    - name: hugo
+      image: eclipsecbi/hugo_extended:0.78.1
+      imagePullPolicy: Always
+      command:
+      - cat
+      tty: true
+  volumes:
+  - configMap:
+      name: known-hosts
+    name: volume-known-hosts
+"""
+    }
+  }
+ 
+  environment {
+    PROJECT_NAME = "ecp"
+    PROJECT_BOT_NAME = "ECP Bot"
+    PROJECT_SUB = "/emfforms"
+  }
+ 
+  triggers { pollSCM('H/10 * * * *') 
+ 
+ }
+ 
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '5'))
+    checkoutToSubdirectory('hugo')
+  }
+ 
+  stages {
+    stage('Update submodule') {
+      steps {
+        dir('hugo') {
+            sh 'git submodule update --init'
+        }
+      }
+    }
+    stage('Checkout www repo') {
+      steps {
+        dir('www') {
+            sshagent(['git.eclipse.org-bot-ssh']) {
+                sh '''
+                    git clone ssh://genie.${PROJECT_NAME}@git.eclipse.org:29418/www.eclipse.org/${PROJECT_NAME}.git .
+                    git checkout ${BRANCH_NAME}
+                '''
+            }
+        }
+      }
+    }
+    stage('Build website (master) with Hugo') {
+      when {
+        branch 'master'
+      }
+      steps {
+        container('hugo') {
+            dir('hugo') {
+                sh 'hugo -b https://www.eclipse.org/${PROJECT_NAME}${PROJECT_SUB}/'
+            }
+        }
+      }
+    }
+    stage('Build website (staging) with Hugo') {
+      when {
+        branch 'staging'
+      }
+      steps {
+        container('hugo') {
+            dir('hugo') {
+                sh 'hugo -b https://staging.eclipse.org/${PROJECT_NAME}${PROJECT_SUB}/'
+            }
+        }
+      }
+    }
+    stage('Push to $env.BRANCH_NAME branch') {
+      when {
+        anyOf {
+          branch "master"
+          branch "staging"
+        }
+      }
+      steps {
+        sh 'rm -rf www${PROJECT_SUB}/* && cp -Rvf hugo/public/* www${PROJECT_SUB}/'
+        dir('www') {
+            sshagent(['git.eclipse.org-bot-ssh']) {
+                sh '''
+                git add -A
+                if ! git diff --cached --exit-code; then
+                  echo "Changes have been detected, publishing to repo 'www.eclipse.org/${PROJECT_NAME}'"
+                  git config user.email "${PROJECT_NAME}-bot@eclipse.org"
+                  git config user.name "${PROJECT_BOT_NAME}"
+                  git commit -m "Website build ${JOB_NAME}-${BUILD_NUMBER}"
+                  git log --graph --abbrev-commit --date=relative -n 5
+                  git push origin HEAD:${BRANCH_NAME}
+                else
+                  echo "No change have been detected since last build, nothing to publish"
+                fi
+                '''
+            }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Build and update EMF Forms website. Also adapts submodule to https (from ssh) connection so Jenkins can pull without credentials.

The Jenkinsfile is adapted to the special website structure of ECP + EMF Forms and leaves the top directory in place, only replacing the `emfforms` subdirectory.

The Jenkins build job can be found [here](https://ci.eclipse.org/ecp/job/Build%20and%20deploy%20EMF%20Forms%20website%20on%20staging%20and%20master/).