### PR TITLE
Change emf.cloud url to http://emf.cloud

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -106,7 +106,7 @@ lastmod = ["lastmod", ":git", "date"]
   weight = 10
 
 [[menu.footer]]
-  url = "https://emf.cloud"
+  url = "http://emf.cloud"
   name = "EMF Cloud"
   weight = 5
 


### PR DESCRIPTION
The emf.cloud website does not load if it is linked using the
https://emf.cloud url.
This is because of redirects not working correctly for https.

This is a temporary solution and must be fixed on the emf.cloud side.