### PR TITLE
Remove zip file of target update site for 1.11 release

### DIFF
--- a/content/downloads/releases/111.md
+++ b/content/downloads/releases/111.md
@@ -5,8 +5,6 @@ weight = 1130
 Update Site (to be installed into your IDE):\
 **[http://download.eclipse.org/ecp/releases/releases_111/](http://download.eclipse.org/ecp/releases/releases_target_111/)**\
 \
-**[Download Update Site as a zip file](http://www.eclipse.org/downloads/download.php?file=/ecp/releases/releases_111/1110/1110.zip)**\
-\
 Target Update Site (DO NOT INSTALL THIS INTO YOUR IDE. THIS IS MEANT ONLY FOR YOUR TARGET PLATFORM!):\
 **[http://download.eclipse.org/ecp/releases/releases_target_111/](http://download.eclipse.org/ecp/releases/releases_target_111/)**\
 \


### PR DESCRIPTION
The zip file is not available anymore and thus the link is removed.